### PR TITLE
Fix some undefined behavior

### DIFF
--- a/include/QuantumSSAOps.td
+++ b/include/QuantumSSAOps.td
@@ -997,7 +997,7 @@ def ApplyCircOp : QuantumSSA_Op<"apply"> {
     }];
 
     let extraClassDeclaration = [{
-        static TypeRange filterRegSize(TypeRange types, MLIRContext *ctx) {
+        static llvm::SmallVector<Type, 8> filterRegSize(TypeRange types, MLIRContext *ctx) {
             Type rstate = RstateType::get(ctx, llvm::None);
             llvm::SmallVector<Type, 8> filteredTypes;
             filteredTypes.reserve(types.size());

--- a/include/QuantumSSAOps.td
+++ b/include/QuantumSSAOps.td
@@ -242,7 +242,8 @@ def ExtractOp : QuantumSSA_Op<"extract", [NoSideEffect]> {
 
             // bounds checking (if possible)
             if(this->const_idx()) {
-                for (auto idxAttr : *this->const_idx()) {
+                auto idxs = *this->const_idx();
+                for (auto idxAttr : idxs) {
                     int64_t idx = idxAttr.dyn_cast<IntegerAttr>().getInt();
                     if (idx >= regsize)
                         return this->emitOpError() << "detected index value out of bounds, idx: "


### PR DESCRIPTION
On my machine one of the `quantum-opt` tests crashes:

```
quantum-opt: .../llvm-project/mlir/include/mlir/IR/Attributes.h:1553: bool mlir::Attribute::isa() const [U = mlir::IntegerAttr]: Assertion `impl && "isa<> used on a null attribute."' failed.
PLEASE submit a bug report to https://bugs.llvm.org/ and include the crash backtrace.
Stack dump:
0.      Program arguments: .../QIRO/build/bin/quantum-opt ../../test/testssa.mlir
 #0 0x0000000000f05243 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) .../llvm-project/llvm/lib/Support/Unix/Signals.inc:563:13
 #1 0x0000000000f034d0 llvm::sys::RunSignalHandlers() .../llvm-project/llvm/lib/Support/Signals.cpp:72:18
 #2 0x0000000000f05700 SignalHandler(int) .../llvm-project/llvm/lib/Support/Unix/Signals.inc:0:3
 #3 0x00007fd06c860b50 __restore_rt (/lib64/libc.so.6+0x3cb50)
 #4 0x00007fd06c8b0e7c __pthread_kill_implementation (/lib64/libc.so.6+0x8ce7c)
 #5 0x00007fd06c860aa6 gsignal (/lib64/libc.so.6+0x3caa6)
 #6 0x00007fd06c84a7fc abort (/lib64/libc.so.6+0x267fc)
 #7 0x00007fd06c84a71b _nl_load_domain.cold (/lib64/libc.so.6+0x2671b)
 #8 0x00007fd06c859656 (/lib64/libc.so.6+0x35656)
 #9 0x0000000000b5b78b mlir::quantumssa::RstateType mlir::Type::cast<mlir::quantumssa::RstateType>() const .../llvm-project/mlir/include/mlir/IR/Types.h:308:3
#10 0x0000000000b5b78b mlir::quantumssa::ExtractOp::verify() .../QIRO/build/include/QuantumSSAOps.cpp.inc:3423:52
#11 0x0000000000b6b261 mlir::failed(mlir::LogicalResult) .../llvm-project/mlir/include/mlir/Support/LogicalResult.h:47:23
#12 0x0000000000b6b261 mlir::Op<mlir::quantumssa::ExtractOp, mlir::OpTrait::ZeroRegion, mlir::OpTrait::AtLeastNResults<1u>::Impl, mlir::OpTrait::ZeroSuccessor, mlir::OpTrait::AtLeastNOperands<1u>::Impl, mlir::MemoryEffectOpInterface::Trait, mlir::OpAsmOpInterface::Trait>::verifyInvariants(mlir::Operation*) .../llvm-project/mlir/include/mlir/IR/OpDefinition.h:1311:9
#13 0x0000000000ead5f2 (anonymous namespace)::OperationVerifier::verifyOperation(mlir::Operation&) .../llvm-project/mlir/lib/IR/Verifier.cpp:0:24
#14 0x0000000000ead8e6 mlir::failed(mlir::LogicalResult) .../llvm-project/mlir/include/mlir/Support/LogicalResult.h:47:23
#15 0x0000000000ead8e6 (anonymous namespace)::OperationVerifier::verifyBlock(mlir::Block&) .../llvm-project/mlir/lib/IR/Verifier.cpp:143:9
#16 0x0000000000ead8e6 (anonymous namespace)::OperationVerifier::verifyRegion(mlir::Region&) .../llvm-project/mlir/lib/IR/Verifier.cpp:122:16
#17 0x0000000000ead8e6 (anonymous namespace)::OperationVerifier::verifyOperation(mlir::Operation&) .../llvm-project/mlir/lib/IR/Verifier.cpp:206:16
#18 0x0000000000ead356 (anonymous namespace)::OperationVerifier::verify(mlir::Operation&) .../llvm-project/mlir/lib/IR/Verifier.cpp:0:14
#19 0x0000000000ead356 mlir::verify(mlir::Operation*) .../llvm-project/mlir/lib/IR/Verifier.cpp:295:46
#20 0x0000000000e23426 mlir::parseSourceFile(llvm::SourceMgr const&, mlir::MLIRContext*) .../llvm-project/mlir/lib/Parser/Parser.cpp:0:14
#21 0x0000000000cff780 mlir::MLIRContext::enableMultithreading(bool) .../llvm-project/mlir/include/mlir/IR/MLIRContext.h:114:27
#22 0x0000000000cff780 performActions(llvm::raw_ostream&, bool, bool, llvm::SourceMgr&, mlir::MLIRContext*, mlir::PassPipelineCLParser const&) .../llvm-project/mlir/lib/Support/MlirOptMain.cpp:56:12
#23 0x0000000000cfe2a0 processBuffer(llvm::raw_ostream&, std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, bool, bool, bool, bool, mlir::PassPipelineCLParser const&, mlir::DialectRegistry&) .../llvm-project/mlir/lib/Support/MlirOptMain.cpp:103:12
#24 0x0000000000cfe037 mlir::MlirOptMain(llvm::raw_ostream&, std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, mlir::PassPipelineCLParser const&, mlir::DialectRegistry&, bool, bool, bool, bool, bool) .../llvm-project/mlir/lib/Support/MlirOptMain.cpp:140:10
#25 0x0000000000cfe744 mlir::MlirOptMain(int, char**, llvm::StringRef, mlir::DialectRegistry&, bool) .../llvm-project/mlir/lib/Support/MlirOptMain.cpp:223:14
#26 0x000000000061503e mlir::failed(mlir::LogicalResult) .../llvm-project/mlir/include/mlir/Support/LogicalResult.h:47:23
#27 0x000000000061503e main .../QIRO/quantum-opt/quantum-opt.cpp:54:12
#28 0x00007fd06c84b510 __libc_start_call_main (/lib64/libc.so.6+0x27510)
#29 0x00007fd06c84b5c9 __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x275c9)
#30 0x0000000000614b35 _start (.../QIRO/build/bin/quantum-opt+0x614b35)
ninja: build stopped: subcommand failed.
```

With these changes the tests pass with AddressSanitizer and UndefinedBehaviorSanitizer enabled.